### PR TITLE
QOL improvements

### DIFF
--- a/KinBase/KinBase.xcodeproj/project.pbxproj
+++ b/KinBase/KinBase.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13EBE3CD7DE1F81A8C3FAD8C /* Pods_KinBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641FFE9E2F6D7EF63FD3F189 /* Pods_KinBase.framework */; };
+		537A853674F90E24C6AB923F /* Pods_KinBaseTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DC34DA43FCC42CF67BA8F4B /* Pods_KinBaseTests.framework */; };
 		851B278A2432821D004EE486 /* SecureKeyStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851B27892432821D004EE486 /* SecureKeyStorage.swift */; };
 		851B278C24328225004EE486 /* KeyChainStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851B278B24328225004EE486 /* KeyChainStorageTests.swift */; };
 		851B279624354AF9004EE486 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 851B279524354AF9004EE486 /* AppDelegate.swift */; };
@@ -184,9 +186,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		285C3EB9856DFBB98A11AB9B /* Pods-KinBaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBaseTests.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBaseTests/Pods-KinBaseTests.debug.xcconfig"; sourceTree = "<group>"; };
-		37DFF5A47EDA55DD46001B68 /* Pods-KinBase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBase.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBase/Pods-KinBase.debug.xcconfig"; sourceTree = "<group>"; };
-		4022398A8F4ED08AED14DADF /* Pods_KinBaseTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KinBaseTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		19892C27E40C49FACB5A6177 /* Pods-KinBase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBase.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBase/Pods-KinBase.debug.xcconfig"; sourceTree = "<group>"; };
+		3DC34DA43FCC42CF67BA8F4B /* Pods_KinBaseTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KinBaseTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		403F37376E7F5C42418E59E7 /* Pods-KinBase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBase.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBase/Pods-KinBase.release.xcconfig"; sourceTree = "<group>"; };
+		4566609EC038826E908FA1FA /* Pods-KinBaseTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBaseTests.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBaseTests/Pods-KinBaseTests.release.xcconfig"; sourceTree = "<group>"; };
+		641FFE9E2F6D7EF63FD3F189 /* Pods_KinBase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KinBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8518B10D244C9BE300EC329B /* KinServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KinServiceTests.swift; sourceTree = "<group>"; };
 		851B27892432821D004EE486 /* SecureKeyStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureKeyStorage.swift; sourceTree = "<group>"; };
 		851B278B24328225004EE486 /* KeyChainStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyChainStorageTests.swift; sourceTree = "<group>"; };
@@ -351,8 +355,7 @@
 		BDD51F04268014EE0061712E /* AirdropService.pbrpc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirdropService.pbrpc.h; sourceTree = "<group>"; };
 		BDD51F05268014EE0061712E /* AirdropService.pbobjc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AirdropService.pbobjc.m; sourceTree = "<group>"; };
 		BDD51F06268014EE0061712E /* AirdropService.pbrpc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AirdropService.pbrpc.m; sourceTree = "<group>"; };
-		C134372677B828BB1D687DC1 /* Pods-KinBase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBase.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBase/Pods-KinBase.release.xcconfig"; sourceTree = "<group>"; };
-		E5C131A473595E1648F2E14A /* Pods-KinBaseTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBaseTests.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBaseTests/Pods-KinBaseTests.release.xcconfig"; sourceTree = "<group>"; };
+		E3BEFD5BD9AE1D6F0ACCC40E /* Pods-KinBaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinBaseTests.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-KinBaseTests/Pods-KinBaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -367,7 +370,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E2F9CDCB79D6C73F8A77A660 /* Pods_KinBase.framework in Frameworks */,
+				13EBE3CD7DE1F81A8C3FAD8C /* Pods_KinBase.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,7 +379,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				85B024072371CC7700829FD6 /* KinBase.framework in Frameworks */,
-				BD4A83C675B37F7AAD4832EC /* Pods_KinBaseTests.framework in Frameworks */,
+				537A853674F90E24C6AB923F /* Pods_KinBaseTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,8 +390,8 @@
 			isa = PBXGroup;
 			children = (
 				853EC7B824EF582F004E0BED /* KinGrpcApi.framework */,
-				9AEB96831A9FD62C8C0DAA5F /* Pods_KinBase.framework */,
-				4022398A8F4ED08AED14DADF /* Pods_KinBaseTests.framework */,
+				641FFE9E2F6D7EF63FD3F189 /* Pods_KinBase.framework */,
+				3DC34DA43FCC42CF67BA8F4B /* Pods_KinBaseTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -396,10 +399,10 @@
 		75D5C99AC419743FE72EB422 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				37DFF5A47EDA55DD46001B68 /* Pods-KinBase.debug.xcconfig */,
-				C134372677B828BB1D687DC1 /* Pods-KinBase.release.xcconfig */,
-				285C3EB9856DFBB98A11AB9B /* Pods-KinBaseTests.debug.xcconfig */,
-				E5C131A473595E1648F2E14A /* Pods-KinBaseTests.release.xcconfig */,
+				19892C27E40C49FACB5A6177 /* Pods-KinBase.debug.xcconfig */,
+				403F37376E7F5C42418E59E7 /* Pods-KinBase.release.xcconfig */,
+				E3BEFD5BD9AE1D6F0ACCC40E /* Pods-KinBaseTests.debug.xcconfig */,
+				4566609EC038826E908FA1FA /* Pods-KinBaseTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1010,7 +1013,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85B024112371CC7700829FD6 /* Build configuration list for PBXNativeTarget "KinBase" */;
 			buildPhases = (
-				7ECD479421B030586B57BD4D /* [CP] Check Pods Manifest.lock */,
+				762BB07B4E0CC5D225E5F5AE /* [CP] Check Pods Manifest.lock */,
 				85B023F82371CC7700829FD6 /* Headers */,
 				85B023F92371CC7700829FD6 /* Sources */,
 				85B023FA2371CC7700829FD6 /* Frameworks */,
@@ -1029,11 +1032,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85B024142371CC7700829FD6 /* Build configuration list for PBXNativeTarget "KinBaseTests" */;
 			buildPhases = (
-				3B87647EE58B13A77BB19BB8 /* [CP] Check Pods Manifest.lock */,
+				DEFE1F0A5BBDD338F2009E98 /* [CP] Check Pods Manifest.lock */,
 				85B024022371CC7700829FD6 /* Sources */,
 				85B024032371CC7700829FD6 /* Frameworks */,
 				85B024042371CC7700829FD6 /* Resources */,
-				5B394E10F1418F8143C10834 /* [CP] Embed Pods Frameworks */,
+				D5F346929C7D29DF6629C589 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1117,7 +1120,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3B87647EE58B13A77BB19BB8 /* [CP] Check Pods Manifest.lock */ = {
+		762BB07B4E0CC5D225E5F5AE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1132,14 +1135,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-KinBaseTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-KinBase-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5B394E10F1418F8143C10834 /* [CP] Embed Pods Frameworks */ = {
+		D5F346929C7D29DF6629C589 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1156,7 +1159,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KinBaseTests/Pods-KinBaseTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7ECD479421B030586B57BD4D /* [CP] Check Pods Manifest.lock */ = {
+		DEFE1F0A5BBDD338F2009E98 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1171,7 +1174,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-KinBase-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-KinBaseTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1522,7 +1525,7 @@
 		};
 		85B024122371CC7700829FD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 37DFF5A47EDA55DD46001B68 /* Pods-KinBase.debug.xcconfig */;
+			baseConfigurationReference = 19892C27E40C49FACB5A6177 /* Pods-KinBase.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -1562,7 +1565,7 @@
 		};
 		85B024132371CC7700829FD6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C134372677B828BB1D687DC1 /* Pods-KinBase.release.xcconfig */;
+			baseConfigurationReference = 403F37376E7F5C42418E59E7 /* Pods-KinBase.release.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CLANG_ENABLE_MODULES = YES;
@@ -1603,7 +1606,7 @@
 		};
 		85B024152371CC7700829FD6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 285C3EB9856DFBB98A11AB9B /* Pods-KinBaseTests.debug.xcconfig */;
+			baseConfigurationReference = E3BEFD5BD9AE1D6F0ACCC40E /* Pods-KinBaseTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -1624,7 +1627,7 @@
 		};
 		85B024162371CC7700829FD6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E5C131A473595E1648F2E14A /* Pods-KinBaseTests.release.xcconfig */;
+			baseConfigurationReference = 4566609EC038826E908FA1FA /* Pods-KinBaseTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/KinBase/KinBase/Src/AppInfoProvider.swift
+++ b/KinBase/KinBase/Src/AppInfoProvider.swift
@@ -13,6 +13,20 @@ public protocol AppInfoProvider {
     func getPassthroughAppUserCredentials() -> AppUserCredentials
 }
 
+public class BasicAppInfoProvider: AppInfoProvider {
+    public var appInfo: AppInfo
+    private var appUserCredentials: AppUserCredentials
+
+    public func getPassthroughAppUserCredentials() -> AppUserCredentials {
+        return self.appUserCredentials
+    }
+
+    public init(appInfo: AppInfo, appUserId: String, appUserPasskey: String) {
+        self.appInfo = appInfo
+        self.appUserCredentials = AppUserCredentials.init(appUserId: appUserId, appUserPasskey: appUserPasskey)
+    }
+}
+
 public class DummyAppInfoProvider: AppInfoProvider {
     public var appInfo: AppInfo {
         return .testApp

--- a/KinBase/KinBase/Src/KinEnvironment.swift
+++ b/KinBase/KinBase/Src/KinEnvironment.swift
@@ -67,7 +67,7 @@ public struct KinEnvironment {
             let logger = KinLoggerFactoryImpl(isLoggingEnabled: enableLogging)
             let networkHandler = NetworkOperationHandler()
             // If custom storagePath is set, use that. Otherwise provide a default.
-            let documentDirectory = storagePath ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let documentDirectory = storagePath ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("kin_storage", isDirectory: true)
             let storage = KinFileStorage(directory: documentDirectory, network: network)
             
             let grpcProxy = AgoraGrpcProxy(

--- a/KinBase/KinBase/Src/Model/KinTransaction.swift
+++ b/KinBase/KinBase/Src/Model/KinTransaction.swift
@@ -247,6 +247,13 @@ extension KinTransactionHash: CustomStringConvertible {
     }
 }
 
+// MARK: - Base58 -
+extension KinTransactionHash {
+    public var base58: String {
+        return Base58.base58FromBytes(rawValue)
+    }
+}
+
 public struct KinTransactions {
     public let items: [KinTransaction]
     public let headPagingToken: PagingToken?

--- a/KinBase/KinBase/Src/Storage/KinFileStorage.swift
+++ b/KinBase/KinBase/Src/Storage/KinFileStorage.swift
@@ -339,18 +339,14 @@ extension KinFileStorage: KinStorageType {
         userDefaults.removeObject(forKey: Constants.minFeeUserDefaultsKey)
         userDefaults.removeObject(forKey: Constants.minApiVersionUserDefaultsKey)
         userDefaults.removeObject(forKey: Constants.cidUserDefaultsKey)
-        return removeFileOrDirectory(kinStorageDirectory)
+        return removeFileOrDirectory(rootDirectory)
     }
 }
 
 // MARK: Private - File Location
 private extension KinFileStorage {
-    var kinStorageDirectory: URL {
-        return rootDirectory.appendingPathComponent("kin_storage", isDirectory: true)
-    }
-
     var directoryForAllAccounts: URL {
-        return kinStorageDirectory.appendingPathComponent("kin_accounts", isDirectory: true)
+        return rootDirectory.appendingPathComponent("kin_accounts", isDirectory: true)
     }
 
     func directoryForAccount(_ account: PublicKey) -> URL {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![jazzy](https://img.shields.io/badge/docs-jazzy-blue)](https://kinecosystem.github.io/kin-ios/)
 [![CocoaPods](https://img.shields.io/cocoapods/v/KinBase.svg?color=6f41e8)](https://cocoapods.org/pods/KinBase)
 
-Use the Kin SDK for iOS to enable the use of Kin inside of your app. Include only the functionality you need to provide the right experience to your users. Use just the base library to access the lightest-weight wrapper over the Kin crytocurrency.
+Use the Kin SDK for iOS to enable the use of Kin inside of your app. Include only the functionality you need to provide the right experience to your users. Use just the base library to access the lightest-weight wrapper over the Kin cryptocurrency.
 
 ## Looking for a quick way to start?
 
@@ -42,3 +42,7 @@ The [`/KinSampleApp`](KinSampleApp) directory includes a sample application. On 
 ## Documentation
 
 Jazzy Documentation for all classes in all modules located [here](https://kinecosystem.github.io/kin-ios/)
+
+## Apps using legacy versions
+
+For specific instructions related to migrating from older versions, see the [migration help document](migration_help.md).

--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@
 [![CocoaPods](https://img.shields.io/cocoapods/v/KinBase.svg?color=6f41e8)](https://cocoapods.org/pods/KinBase)
 
 Use the Kin SDK for iOS to enable the use of Kin inside of your app. Include only the functionality you need to provide the right experience to your users. Use just the base library to access the lightest-weight wrapper over the Kin cryptocurrency.
-<<<<<<< HEAD
 
 ## Looking for a quick way to start?
-=======
->>>>>>> c6d6b7aaca7bf7d36bf3a803913bf7040945858d
 
 The quickest way to get started is by following the [tutorial](https://kintegrate.dev/tutorials/getting-started-ios-sdk/) or by downloading the [starter kit](https://kintegrate.dev/starters/kin-ios-starter/).
 

--- a/migration_help.md
+++ b/migration_help.md
@@ -1,0 +1,23 @@
+# Migrating from 0.x to 1.x
+
+## Kin Storage
+Prior to version 1.0.0, Kin accounts were stored inside directories specific to the environment being used (mainnet, testnet, kin2, kin3, etc). This has been deprecated in version 1.0.0. The new default is for Kin storage to reside at `~/Documents/kin_storage`. Legacy apps wishing to maintain support for their existing users are advised to use the `storagePath` parameter when initializing their `KinEnvironment` to provide a custom storage path pointing to where previous versions of the Kin SDK stored its data.
+
+### Sample code for migrating apps
+```
+var customPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+customPath.appendPathComponent("kin_storage")
+customPath.appendPathComponent("env")
+customPath.appendPathComponent("[ENV_ID]")
+let environment = KinEnvironment.Agora.mainNet(appInfoProvider: yourAppInfoProvider, storagePath: customPath)
+```
+
+#### Kin3 apps
+Replace `[ENV_ID]` in the above example with `9DKMS82DC5KMSRJ5EGG3M824CLHMARB2CLP20CHG64S0====`
+
+#### Kin2 apps
+Replace `[ENV_ID]` in the above example with `A1QM4R39CCG4ER3FC9GMO82BD5N20HB3DTPNISRKCLMI0JJ5EHRMUSJB40TI0IJLDPII0CHG64S0====`
+
+#### Other
+The `ENV_ID` referenced above is the base32hex encoding of the KinNetwork.Id your app was using prior to updating to 1.x. Listed above are the encodings for Kin3 mainnet and Kin2 mainnet, but if you had a different configuration, you can use a base32hex encoder to generate the appropriate string, or check an existing device to find the precise storage location it was using.
+


### PR DESCRIPTION
- Added a `BasicAppInfoProvider` class to make it easier to provide app info without excess boilerplate
- Extended `KinTransactionHash` with a .base58 property (provides the string used to reference the transaction on the Solana blockchain, matches existing `PublicKey.base58` extension)
- Modified the KinStorage configuration to support all legacy situations and still provide a sensible default going forward
- Updated readmes to reflect semantic changes in 1.x
- Added a separate doc for migrating apps with information specific to them
- Fixed typos